### PR TITLE
chore: Migrate to uv package manager and fix CI pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,9 @@
-name: build
+name: Test
 
 on:
   - push
   - pull_request
+  - workflow_dispatch
 
 jobs:
   pytest:
@@ -21,28 +22,37 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: pdm-project/setup-pdm@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: True
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-      - run: pdm install --dev --no-self --no-default
-      - run: pdm run tox -e ${{ matrix.env }} -- -vv
+      - run: uv sync --dev
+      - run: uv run tox -e ${{ matrix.env }} -- -vv
 
   ruff-check:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: pdm-project/setup-pdm@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: True
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pdm install --dev --no-self --no-default
-      - run: pdm run ruff check --no-fix --diff
+      - run: uv sync --dev
+      - run: uv run ruff check --no-fix --diff
 
   ruff-format:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: pdm-project/setup-pdm@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: True
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pdm install --dev --no-self --no-default
-      - run: pdm run ruff format --diff --check
+      - run: uv sync --dev
+      - run: uv run ruff format --diff --check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,24 +2,10 @@
 name = "salt-pki"
 version = "1.0.1"
 dependencies = ["acme", "cryptography", "distro", "salt"]
-requires-python = ">=3.8.2,<4.0"
+requires-python = ">=3.10,<4.0"
 
 [project.optional-dependencies]
-test = [
-    "matchlib",
-    "pylint~=3.2.3",
-    "pytest~=8.3.2",
-]
-
-[tool.pdm.dev-dependencies]
-dev = [
-    "matchlib>=0.2.1",
-    "mypy~=1.3",
-    "pylint~=3.2.3",
-    "pytest~=8.3.1",
-    "ruff==0.8.4",
-    "tox~=4.23.2",
-]
+test = ["matchlib", "pylint~=3.2.3", "pytest~=8.3.2"]
 
 [tool.pyright]
 include = ["salt_tower", "test"]
@@ -37,6 +23,12 @@ docstring-code-format = true
 [tool.ruff.lint]
 extend-select = ["I"]
 
-[build-system]
-requires = ["pdm-pep517"]
-build-backend = "pdm.pep517.api"
+[tool.uv]
+dev-dependencies = [
+    "matchlib",
+    "mypy~=1.3",
+    "pylint~=3.2.3",
+    "pytest~=8.3.2",
+    "ruff==0.8.4",
+    "tox~=4.23.2",
+]


### PR DESCRIPTION
Migrate to using uv package manager that has less issues to stay working in CI.